### PR TITLE
Change -f to -F to handle log rotation

### DIFF
--- a/lib/capistrano/logtail/utility.rb
+++ b/lib/capistrano/logtail/utility.rb
@@ -12,7 +12,7 @@ module Capistrano
 
         cmd = [
             :tail,
-            '-f',
+            '-F',
             "-n#{lines}",
             *files
           ].join(' ')


### PR DESCRIPTION
From the unix man page http://man7.org/linux/man-pages/man1/tail.1.html:   -F    same as --follow=name --retry

If the log is rotated it will still follow the correct file.
